### PR TITLE
add an option to set the TTL on responses

### DIFF
--- a/ipin.go
+++ b/ipin.go
@@ -19,6 +19,7 @@ const Name = "ipin"
 type IpInName struct {
 	// When process failed, will call next plugin
 	Fallback bool
+	Ttl uint32
 	Next     plugin.Handler
 }
 
@@ -40,14 +41,14 @@ func (self IpInName) Resolve(ctx context.Context, w dns.ResponseWriter, r *dns.M
 
 		var rr dns.RR
 		rr = new(dns.A)
-		rr.(*dns.A).Hdr = dns.RR_Header{Name: state.QName(), Rrtype: dns.TypeA, Class: state.QClass()}
+		rr.(*dns.A).Hdr = dns.RR_Header{Name: state.QName(), Rrtype: dns.TypeA, Class: state.QClass(), Ttl: self.Ttl}
 		rr.(*dns.A).A = net.ParseIP(ip).To4()
 
 		a.Answer = []dns.RR{rr}
 
 		if len(matches[2]) > 0 {
 			srv := new(dns.SRV)
-			srv.Hdr = dns.RR_Header{Name: "_port." + state.QName(), Rrtype: dns.TypeSRV, Class: state.QClass()}
+			srv.Hdr = dns.RR_Header{Name: "_port." + state.QName(), Rrtype: dns.TypeSRV, Class: state.QClass(), Ttl: self.Ttl}
 			if state.QName() == "." {
 				srv.Hdr.Name = "_port." + state.QName()
 			}

--- a/ipin_test.go
+++ b/ipin_test.go
@@ -12,13 +12,14 @@ import (
 )
 
 func TestWhoami(t *testing.T) {
-	wh := ipin.IpInName{}
+	wh := ipin.IpInName{ Ttl: uint32(86400) }
 
 	tests := []struct {
 		qname         string
 		qtype         uint16
 		expectedCode  int
 		expectedReply []string // ownernames for the records in the additional section.
+		expectedTtl  uint32
 		expectedErr   error
 	}{
 		{
@@ -26,6 +27,7 @@ func TestWhoami(t *testing.T) {
 			qtype:         dns.TypeA,
 			expectedCode:  dns.RcodeSuccess,
 			expectedReply: []string{"192-168-1-2-80.example.org.", "_port.192-168-1-2-80.example.org."},
+			expectedTtl:   uint32(86400),
 			expectedErr:   nil,
 		},
 	}
@@ -56,6 +58,10 @@ func TestWhoami(t *testing.T) {
 			expected = tc.expectedReply[1]
 			if actual != expected {
 				t.Errorf("Test %d: Expected answer %s, but got %s", i, expected, actual)
+			}
+
+			if rec.Msg.Extra[0].Header().Ttl != tc.expectedTtl {
+				t.Errorf("Test %d: Expected answer %d, but got %d", i, tc.expectedTtl, rec.Msg.Extra[0].Header().Ttl)
 			}
 		}
 	}

--- a/setup.go
+++ b/setup.go
@@ -1,6 +1,8 @@
 package ipin
 
 import (
+	"strconv"
+
 	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
@@ -22,6 +24,16 @@ func setup(c *caddy.Controller) error {
 		switch x {
 		case "fallback":
 			ipin.Fallback = true
+		case "ttl":
+			args := c.RemainingArgs()
+			if len(args) < 1 {
+				return c.Errf("ttl needs a time in second")
+			}
+			ttl, err := strconv.Atoi(args[0])
+			if err != nil {
+				return c.Errf("ttl provided is invalid")
+			}
+			ipin.Ttl = uint32(ttl)
 		default:
 			return plugin.Error(Name, c.Errf("unexpected '%v' command", x))
 		}

--- a/setup_test.go
+++ b/setup_test.go
@@ -30,4 +30,18 @@ fallback invalid
 	if err := setup(c); err == nil {
 		t.Fatalf("Expected errors, but got: %v", err)
 	}
+
+	c = caddy.NewTestController("dns", `ipin {
+ttl invalid
+}`)
+	if err := setup(c); err == nil {
+		t.Fatalf("Expected errors, but got: %v", err)
+	}
+
+	c = caddy.NewTestController("dns", `ipin {
+ttl 86400
+}`)
+	if err := setup(c); err != nil {
+		t.Fatalf("Expected no errors, but got: %v", err)
+	}
 }


### PR DESCRIPTION
This allows one to optionally configure ttl for responses in the config:

ipin {
  ttl 86400
}