### PR TITLE
add ability to resolve IPv6 address

### DIFF
--- a/ipin_test.go
+++ b/ipin_test.go
@@ -30,6 +30,14 @@ func TestWhoami(t *testing.T) {
 			expectedTtl:   uint32(86400),
 			expectedErr:   nil,
 		},
+		{
+			qname:         "fe80--1ff-fe23-4567-890a.example.org",
+			qtype:         dns.TypeAAAA,
+			expectedCode:  dns.RcodeSuccess,
+			expectedReply: []string{"fe80--1ff-fe23-4567-890a.example.org."},
+			expectedTtl:   uint32(86400),
+			expectedErr:   nil,
+		},
 	}
 
 	ctx := context.TODO()


### PR DESCRIPTION
Resolve IPv6 address in ipv6-literal form back to IPv6 address for DNS look up.

Example:
2001-db8-85a3-8d3-1319-8a2e-370-7348.ipv6-literal.net will resolve to 2001:db8:85a3:8d3:1319:8a2e:370:7348.

There no clear way to indicate port number yet. Thus, it is not added here.